### PR TITLE
Fix Trades/Money tab

### DIFF
--- a/js/pages.js
+++ b/js/pages.js
@@ -61,7 +61,7 @@ const PAGE_INFO = {
 		css: ["messages.css"]
 	},
 	money: {
-		matches: ["^/my/money\\.aspx"],
+		matches: ["^/trades"],
 		css: ["money.css"]
 	},
 	placeconfig: {


### PR DESCRIPTION
Before this commit, clicking on the Trades tab (seen as "Money" when using BTRoblox) on the left of the website would lead to a 404 error, due to the newer site layout. It now takes you to what I believe is the appropriate destination. However, seeing as it used to be referred to as "Money" it might be a good idea to link it to the transactions tab. Alternatively, it can be renamed to something more fitting.