### PR TITLE
Fixed InventoryEmbed redirecting to Inventory page

### DIFF
--- a/js/pages/profile.js
+++ b/js/pages/profile.js
@@ -856,7 +856,7 @@ pageInit.profile = function(userId) {
 
 		if(SETTINGS.get("profile.embedInventoryEnabled") && +userId !== 1) {
 			const cont = html`<div></div>`
-			const iframe = html`<iframe id="btr-injected-inventory" src="/users/${userId}/inventory" scrolling="no">`
+			const iframe = html`<iframe id="btr-injected-inventory" sandbox="allow-same-origin allow-forms allow-scripts" src="/users/${userId}/inventory" scrolling="no">`
 
 			cont.append(iframe)
 			newCont.$find(".placeholder-inventory").replaceWith(cont)


### PR DESCRIPTION
should fix the problem where inventoryembed is being loaded causes it to redirect the top level navigation to the user inventory