### PR TITLE
Lower minimum Firefox version

### DIFF
--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -18,7 +18,7 @@
 	"browser_specific_settings": {
 		"gecko": {
 			"id": "btroblox@antiboomz.com",
-			"strict_min_version": "107.0"
+			"strict_min_version": "102.0"
 		}
 	},
 	


### PR DESCRIPTION
The newest version of the extensions works fine on Firefox 102, which is the latest ESR release.