### PR TITLE
Tweak sidebar separator padding

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -172,6 +172,16 @@ a:hover .icon-nav-message-btr { background-position: -28px 0; } */
 }
 
 
+/* Sidebar Divider Padding Tweak */
+.rbx-left-col ul {
+	/*
+		!important because BTRoblox injects css before Roblox's bundle gets loaded.
+		This fixes an annoying padding issue that has been present on the sidebar since a refactor in 2018.
+	*/
+	padding: 5px 10px 0 10px !important;
+}
+
+
 /* Sidebar Blog Feed */
 
 #btr-blogfeed-container {


### PR DESCRIPTION
This fixes a padding bug that has been present on Roblox's sidebar separator since 2018. Roblox doesn't seem to want to fix it themselves.
I had to make the css use !important because BTRoblox injects its css before Roblox's bundles.

## Changes
**Before**
![image](https://github.com/AntiBoomz/BTRoblox/assets/94338039/ecf39dfb-676b-4441-ac11-04f6958130a2)

**After**
![image](https://github.com/AntiBoomz/BTRoblox/assets/94338039/4eccf88d-0432-4a41-abf4-634637d177b1)