### PR TITLE
Prevent BTRoblox buttons from overlapping native buttons on item details page

### DIFF
--- a/css/itemdetails.css
+++ b/css/itemdetails.css
@@ -40,6 +40,12 @@
 	}
 }
 
+/* avoid overlapping native thumbnail buttons */
+
+.item-details-thumbnail-container .thumbnail-ui-container .bottom-align-container {
+	z-index: 2;
+}
+
 /* old item details */
 
 .menu-shown {


### PR DESCRIPTION
`.btr-thumb-btn-container` needs `pointer-events: all` to ensure the body adjustment pop-up stays active after hovering it's button, but this causes problems with the native buttons _(e.g. "3D" and "Try On")_ because the `padding-bottom: 56px` overlaps them and prevents click-through.

This fix sets the native buttons above the BTR buttons, seems to work from some quick testing, and should properly resolve #129.