### PR TITLE
Fix for R6 avatars not being rendered on catalog pages

### DIFF
--- a/js/rbx/Avatar/Avatar.js
+++ b/js/rbx/Avatar/Avatar.js
@@ -1949,7 +1949,7 @@ const RBXAvatar = (() => {
 					}
 					
 					// Mesh offset (not scaled)
-					if(acc.offset) {
+					if(acc.offset && acc.bakedCFrame) {
 						acc.bakedCFrame.multiply(tempMatrix.makeTranslation(...acc.offset))
 					}
 					


### PR DESCRIPTION
Fix r6 avatars not being rendered on catalog pages due to `acc.bakedCFrame` not existing.

Tested on a local branch and it renders both R6 and R15 avatars properly, not absolutely sure if everything works as intended.