### PR TITLE
Fix community picker covered by menu sidebar

### DIFF
--- a/js/pages/groups.js
+++ b/js/pages/groups.js
@@ -438,6 +438,53 @@ pageInit.groups = () => {
 			})
 		})
 	}
+
+	document.$watch(".groups-list-sidebar", sidebar => {
+		// fix sidebar being covered by menu
+		sidebar.style.left = "174px";
+		sidebar.style.padding = "24px 20px 20px 20px";
+
+		// fix footer container being overlayed by groups list
+		const footerContainer = document.getElementById("footer-container");
+		if (footerContainer) {
+			footerContainer.style.left = "527px";
+		}
+
+		const toggleButton = document.createElement("button");
+		toggleButton.textContent = "<";
+		toggleButton.style.position = "fixed";
+		toggleButton.style.top = "46px";
+		toggleButton.style.left = "468px";
+		toggleButton.style.zIndex = "1000";
+		toggleButton.style.padding = "6px -10px";
+		toggleButton.style.cursor = "pointer";
+		toggleButton.style.fontSize = "14px";
+		toggleButton.style.border = "0px solid #ccc";
+		toggleButton.style.background = "#34353b";
+		toggleButton.style.borderRadius = "24%";
+		toggleButton.style.width = "24px";
+		toggleButton.style.height = "24px";
+
+		let isVisible = true;
+		toggleButton.onclick = () => {
+			isVisible = !isVisible;
+			sidebar.style.visibility = isVisible ? "" : "hidden";
+			toggleButton.textContent = isVisible ? "<" : ">";
+			toggleButton.style.left = isVisible ? "468px" : "182px";
+			// move content to left when sidebar not visible
+			const content = document.getElementById("content");
+			if (content) {
+				content.style.marginLeft = isVisible ? "327px" : "12px";
+			}
+			// fix footer container being overlayed by groups list when visible
+			const footerContainer = document.getElementById("footer-container");
+			if (footerContainer) {
+				footerContainer.style.left = isVisible ? "527px" : "327px";
+			}
+		};
+
+		document.body.appendChild(toggleButton);
+	});
 	
 	onPageReset(() => {
 		document.body?.classList.remove("btr-redesign")

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,111 @@
+{
+	"manifest_version": 3,
+
+	"name": "BTRoblox - Making Roblox Better",
+	"short_name": "BTRoblox",
+	"description": "Enhance your Roblox experience!",
+	"version": "3.6.19",
+	"author": "AntiBoomz",
+
+	"minimum_chrome_version": "96",
+	"incognito": "split",
+
+	"action": {
+		"default_title": "Open BTRoblox Settings"
+	},
+
+	"icons": {
+		"128": "res/icon_128.png"
+	},
+
+	"background": {
+		"service_worker": "js/_chrome/serviceWorker.js"
+	},
+	
+	"host_permissions": [
+		"*://*.roblox.com/",
+		"*://*.rbxcdn.com/"
+	],
+
+	"permissions": [
+		"declarativeNetRequestWithHostAccess",
+		"notifications",
+		"contextMenus",
+		"scripting",
+		"storage",
+		"alarms"
+	],
+
+	"web_accessible_resources": [
+		{
+			"resources": ["/res/*", "/css/*"],
+			"matches": ["*://*.roblox.com/*"]
+		}
+	],
+
+	"content_scripts": [
+		{
+			"matches": [
+				"*://www.roblox.com/*",
+				"*://web.roblox.com/*",
+				"*://create.roblox.com/*"
+			],
+			"exclude_matches": [
+				"*://*/userads/*",
+				"*://*/user-sponsorship/*",
+				"*://*/build/upload",
+				"*://*/*/userads/*",
+				"*://*/*/user-sponsorship/*",
+				"*://*/*/build/upload"
+			],
+			"js": [
+				"js/rbx/Constants.js",
+				
+				"js/shared/common.js",
+				"js/shared/utility.js",
+				"js/shared/messaging.js",
+				"js/shared/sharedData.js",
+				"js/shared/settings.js",
+				"js/shared/contextmenu.js",
+				"js/shared/serverdetails.js",
+				
+				"js/util/injectJS.js",
+				"js/util/injectCSS.js",
+				"js/util/angularHook.js",
+				"js/util/loadOptionalLibrary.js",
+				
+				"js/feat/themes.js",
+				"js/feat/adblock.js",
+				"js/feat/fastSearch.js",
+				"js/feat/navigation.js",
+				"js/feat/robuxToCash.js",
+				"js/feat/settingsModal.js",
+				
+				"js/rbx/AssetCache.js",
+				"js/rbx/RobloxApi.js",
+
+				"js/pages/common.js",
+				"js/pages/avatar.js",
+				"js/pages/catalog.js",
+				"js/pages/friends.js",
+				"js/pages/gamedetails.js",
+				"js/pages/groups.js",
+				"js/pages/groupadmin.js",
+				"js/pages/home.js",
+				"js/pages/inventory.js",
+				"js/pages/itemdetails.js",
+				"js/pages/messages.js",
+				"js/pages/money.js",
+				"js/pages/profile.js",
+				
+				"js/pages/create.js",
+				"js/pages/marketplace.js",
+				
+				"js/inject.js",
+				"js/main.js"
+			],
+			"run_at": "document_start",
+			"all_frames": true
+		}
+	]
+}


### PR DESCRIPTION
- Moves groups-list over to 327px so it no longer gets covered
- adds button to easily expand and collapse the groups/community list. 
- Only dark mode supported for right now.

Closes #154